### PR TITLE
Fix apparent typo

### DIFF
--- a/lib/js/ZCRMRestClient.js
+++ b/lib/js/ZCRMRestClient.js
@@ -35,7 +35,7 @@ var mysql_password = "";
 
     var config_properties = PropertiesReader('resources/configuration.properties');
     
-    mysql_module = properties.get('crm.api.tokenmanagement')?properties.get('crm.api.tokenmanagement'):mysql_module;
+    mysql_module = config_properties.get('crm.api.tokenmanagement')?config_properties.get('crm.api.tokenmanagement'):mysql_module;
 
     baseURL = config_properties.get('crm.api.url')?config_properties.get('crm.api.url'):baseURL;
     


### PR DESCRIPTION
From the style of the code, all of the properties contain crm access details and api contains api relevant data.
The documentation also supports stating that tokenmanagement should be defined within `resources/configruation.properties` (config_properties) but the code was actually looking in `resources/oauth_configuration.properties` (properties) to extract that property.