### PR TITLE
check for mysql password not being string after properties.get is used

### DIFF
--- a/lib/js/ZCRMRestClient.js
+++ b/lib/js/ZCRMRestClient.js
@@ -43,7 +43,10 @@ var default_user_identifier = "zcrm_default_user";
     mysql_username = config_properties.get('mysql.username')?config_properties.get('mysql.username'):mysql_username;
 
     mysql_password = config_properties.get('mysql.password')?config_properties.get('mysql.password'):mysql_password;
-    
+
+    if(typeof mysql_password !== 'string'){
+      mysql_password = mysql_password.toString();
+    }
 
     if(config_properties.get('crm.api.user_identifier')){
 


### PR DESCRIPTION
Hello,

I noticed an issue with the ZCRMRestClient.js and the way it is using the properties and mysql package.
It seems as though the properties.get method does not always return a string. This could be problematic
because one of the authentication methods for mysql requires a string.

example configuration.properties
```
[mysql]
username=example
password=123456789
```

If I try these setting the password as a number the mysql_util will give us an error and we wont be able to connect to the database. It seems this is because of the mysql package method below:

```
Auth.token = function(password, scramble) {
  if (!password) {
    return Buffer.alloc(0);
  }
  // password must be in binary format, not utf8
  console.log("password is ", password);
  var stage1 = sha1((Buffer.from(password, 'utf8')).toString('binary'));
  var stage2 = sha1(stage1);
  var stage3 = sha1(scramble.toString('binary') + stage2);
  return xor(stage3, stage1);
};
```

My pull request should verify that the value for the mysql password is always casted to a string before creating a connection with MySQL.

please review the pull request.

thanks