### PR TITLE
[Urgent] Fix API error path

### DIFF
--- a/lib/js/util.js
+++ b/lib/js/util.js
@@ -125,7 +125,7 @@ function makeapicall(request){
                 resolve(error);
             }
 
-        if(response.statusCode == 204){
+        else if(response.statusCode == 204){
 
              var respObj = {
                             "message" : "no data", //No I18N


### PR DESCRIPTION
Currently, if the http request failed, the code continues to run after `resolve(error)` which results in variable undefined errors (`response` is undefined). This is unhandled and is crashing whatever node.js application using this library.

Please kindly fix and publish a new version on npm. Thank you!